### PR TITLE
Use the port from configuration

### DIFF
--- a/udp_ledstrip.lua
+++ b/udp_ledstrip.lua
@@ -13,5 +13,5 @@ end)
 -- Clear the strip (write all black pixels to it once)
 ws2812.write(pin, string.char(0,  0,  0):rep(pixels))
 
-srv:listen(80)
+srv:listen(port)
 print("LED server running!")


### PR DESCRIPTION
The port is defined in the `config.lua` but not used in the `udp_ledstrip.lua` program.